### PR TITLE
documentation(ES-837798-databindScript): Fix the errors for data not loading using oDataV4 Adoptor in schedule docs

### DIFF
--- a/ej2-javascript/code-snippet/schedule/data-bind-cs2/index.js
+++ b/ej2-javascript/code-snippet/schedule/data-bind-cs2/index.js
@@ -1,12 +1,21 @@
 var dataManager = new ej.data.DataManager({
-    url: 'https://ej2services.syncfusion.com/production/web-services/api/Schedule',
+    url: 'https://services.odata.org/V4/Northwind/Northwind.svc/Orders/',
     adaptor: new ej.data.ODataV4Adaptor(),
     crossDomain: true
 });
 var scheduleObj = new ej.schedule.Schedule({
     height: '550px',
-    selectedDate: new Date(2020, 9, 20),
-    eventSettings: { dataSource: dataManager },
+    selectedDate: new Date(1996, 6, 9),
+    eventSettings: { dataSource: dataManager,
+        fields: {
+            id: 'Id',
+            subject: { name: 'ShipName' },
+            location: { name: 'ShipCountry' },
+            description: { name: 'ShipAddress' },
+            startTime: { name: 'OrderDate' },
+            endTime: { name: 'RequiredDate' },
+            recurrenceRule: { name: 'ShipRegion' }
+        } },
     readonly: true
 });
  scheduleObj.appendTo('#Schedule');

--- a/ej2-javascript/code-snippet/schedule/data-bind-cs2/index.ts
+++ b/ej2-javascript/code-snippet/schedule/data-bind-cs2/index.ts
@@ -5,15 +5,26 @@ import { DataManager, ODataV4Adaptor, Query } from '@syncfusion/ej2-data';
 
 Schedule.Inject(Day, Week, WorkWeek, Month, Agenda);
 let dataManager: DataManager = new DataManager({
-       url: 'https://ej2services.syncfusion.com/production/web-services/api/Schedule',
-       adaptor: new ODataV4Adaptor,
-       crossDomain: true
-   });
+    url: 'https://services.odata.org/V4/Northwind/Northwind.svc/Orders/',
+    adaptor: new ODataV4Adaptor,
+    crossDomain: true
+});
 let scheduleObj: Schedule = new Schedule({
     height: '550px',
-    selectedDate: new Date(2020, 9, 20),
+    selectedDate: new Date(1996, 6, 9),
     readonly: true,
-    eventSettings: { dataSource: dataManager}
+    eventSettings: {
+        dataSource: dataManager,
+        fields: {
+            id: 'Id',
+            subject: { name: 'ShipName' },
+            location: { name: 'ShipCountry' },
+            description: { name: 'ShipAddress' },
+            startTime: { name: 'OrderDate' },
+            endTime: { name: 'RequiredDate' },
+            recurrenceRule: { name: 'ShipRegion' }
+        }
+    }
 });
 scheduleObj.appendTo('#Schedule');
 

--- a/ej2-javascript/code-snippet/schedule/data-bind-cs3/index.js
+++ b/ej2-javascript/code-snippet/schedule/data-bind-cs3/index.js
@@ -8,7 +8,7 @@ var scheduleObj = new ej.schedule.Schedule({
     selectedDate: new Date(1996, 6, 9),
     currentView: 'Month',
     eventSettings: {
-        query: new Query(),
+        query:  new ej.data.Query(),
         includeFiltersInQuery: true, dataSource: dataManager, fields: {
             id: 'Id',
             subject: { name: 'ShipName' },

--- a/ej2-javascript/code-snippet/schedule/data-bind-cs4/index.js
+++ b/ej2-javascript/code-snippet/schedule/data-bind-cs4/index.js
@@ -4,19 +4,30 @@ class CustomAdaptor extends ej.data.ODataV4Adaptor {
         // calling base class processResponse function
         var original = super.processResponse.apply(this, arguments);
         // adding employee id
-        original.forEach( function (item) { item['EmpID'] = ++i});
-        return  original;
+        original.forEach(function (item) { item['EmpID'] = ++i });
+        return original;
     }
 }
 var dataManager = new ej.data.DataManager({
-    url: 'https://ej2services.syncfusion.com/production/web-services/api/Schedule',
+    url: 'https://services.odata.org/V4/Northwind/Northwind.svc/Orders/',
     adaptor: new CustomAdaptor
 });
 var scheduleObj = new ej.schedule.Schedule({
     height: '550px',
-    selectedDate: new Date(2020, 9, 20),
+    selectedDate: new Date(1996, 6, 9),
     readonly: true,
-    eventSettings: { dataSource: dataManager }
+    eventSettings: {
+        dataSource: dataManager,
+        fields: {
+            id: 'Id',
+            subject: { name: 'ShipName' },
+            location: { name: 'ShipCountry' },
+            description: { name: 'ShipAddress' },
+            startTime: { name: 'OrderDate' },
+            endTime: { name: 'RequiredDate' },
+            recurrenceRule: { name: 'ShipRegion' }
+        }
+    }
 });
- scheduleObj.appendTo('#Schedule');
+scheduleObj.appendTo('#Schedule');
 

--- a/ej2-javascript/code-snippet/schedule/data-bind-cs4/index.ts
+++ b/ej2-javascript/code-snippet/schedule/data-bind-cs4/index.ts
@@ -11,19 +11,30 @@ class CustomAdaptor extends ODataV4Adaptor {
         let original: Object[] = super.processResponse.apply(this, arguments);
         // adding employee id
         original.forEach((item: Object) => item['EventID'] = ++i);
-        return  original;
+        return original;
     }
 }
 
 let dataManager: DataManager = new DataManager({
-    url: 'https://ej2services.syncfusion.com/production/web-services/api/Schedule',
+    url: 'https://services.odata.org/V4/Northwind/Northwind.svc/Orders/',
     adaptor: new CustomAdaptor
 });
 let scheduleObj: Schedule = new Schedule({
     height: '550px',
-    selectedDate: new Date(2020, 9, 20),
+    selectedDate: new Date(1996, 6, 9),
     readonly: true,
-    eventSettings: { dataSource: dataManager }
+    eventSettings: {
+        dataSource: dataManager,
+        fields: {
+            id: 'Id',
+            subject: { name: 'ShipName' },
+            location: { name: 'ShipCountry' },
+            description: { name: 'ShipAddress' },
+            startTime: { name: 'OrderDate' },
+            endTime: { name: 'RequiredDate' },
+            recurrenceRule: { name: 'ShipRegion' }
+        }
+    }
 });
 scheduleObj.appendTo('#Schedule');
 


### PR DESCRIPTION
Description:
Fix the datas not loading in remote data binding for typescript and javascript schedule documentation

Root cause: Url link will cause the issue .

Areas affected and ensured:
All possible cases

Test cases:
NA

Test bed sample location:
NA

Additional checklist
Did you run the automation against your fix? NA
Is there any API name change? No
Is there any existing behavior change of other features due to this code change? No
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? NA
Did you record this case in the unit test or UI test? No