### PR TITLE
Documentation(ES-820304): To include note section for timezone in scheduler set to specific timezone for typescript and javascript platform

### DIFF
--- a/ej2-javascript/schedule/timezone.md
+++ b/ej2-javascript/schedule/timezone.md
@@ -54,6 +54,8 @@ The following code example displays an appointment from 9.00 AM to 10.00 AM when
 
 When a time zone is set to Scheduler through `timezone` property, the appointments will be displayed exactly based on the Scheduler timezone regardless of its client timezone. In the following code example, appointments will be displayed based on Eastern Time (UTC -05:00).
 
+>Note: **timezone** property only applicable for the appointment processing and current time indication.
+
 {% if page.publishingplatform == "typescript" %}
 
  {% tabs %}

--- a/ej2-javascript/schedule/timezone.md
+++ b/ej2-javascript/schedule/timezone.md
@@ -13,6 +13,8 @@ domainurl: ##DomainURL##
 
 The Scheduler makes use of the current system time zone by default. If it needs to follow some other user-specific time zone, then the `timezone` property needs to be used. Apart from the default action of applying specific timezone to the Scheduler, it is also possible to set different time zone values for each appointments through the properties `startTimezone` and `endTimezone` which can be defined as separate fields within the event fields collection.
 
+>Note: **timezone** property only applicable for the appointment processing and current time indication.
+
 ## Understanding date manipulation in JavaScript
 
 The `new Date()` in JavaScript returns the exact current date object with complete time and timezone information. For example, it may return value such as `Wed Dec 12 2018 05:23:27 GMT+0530 (India Standard Time)` which indicates that the current date is December 12, 2018 and the current time is 5.23 AM on browsers following the IST timezone.
@@ -53,8 +55,6 @@ The following code example displays an appointment from 9.00 AM to 10.00 AM when
 ## Scheduler set to specific timezone
 
 When a time zone is set to Scheduler through `timezone` property, the appointments will be displayed exactly based on the Scheduler timezone regardless of its client timezone. In the following code example, appointments will be displayed based on Eastern Time (UTC -05:00).
-
->Note: **timezone** property only applicable for the appointment processing and current time indication.
 
 {% if page.publishingplatform == "typescript" %}
 


### PR DESCRIPTION
To include note section for timezone in scheduler set to specific timezone for typescript and javascript platform